### PR TITLE
Adjust automated build to the changed directory path 

### DIFF
--- a/.github/workflows/esp32.yaml
+++ b/.github/workflows/esp32.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Build grblHAL
       uses: docker://espressif/idf:release-v4.3
       with:

--- a/.github/workflows/esp32.yaml
+++ b/.github/workflows/esp32.yaml
@@ -11,9 +11,9 @@ jobs:
       uses: docker://espressif/idf:release-v4.3
       with:
         entrypoint: /opt/esp/entrypoint.sh
-        args: bash -c "cd drivers/ESP32 && idf.py build"
+        args: bash -c "idf.py build"
     - name: Upload the build binary
       uses: actions/upload-artifact@v2
       with:
         name: grbl.bin
-        path: drivers/ESP32/build/grbl.bin
+        path: build/grbl.bin

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A GrblHAL driver for the ESP32 processor. *** Preview version ***
 
-### How to build using ESP-IDF v3.3:
+### How to build using ESP-IDF v4.3:
 
 While this manual briefly describes basic build process on Linux OS, you can find more details
 as well as differences for building on other OS at this webpage:


### PR DESCRIPTION
Adjusts automated build to the changed directory path, fixing the build. Also removes the magically appearing typo in README.