### PR TITLE
Rework of esp uart interface

### DIFF
--- a/main/esp32-hal-uart.c
+++ b/main/esp32-hal-uart.c
@@ -411,7 +411,7 @@ const io_stream_t *serialInit (uint32_t baud_rate)
     uart_driver_install(uart1->num, RX_BUFFER_SIZE, TX_BUFFER_SIZE, RX_BUFFER_SIZE, &_uart1_queue, 0);
 
     serialFlush();
-    xTaskCreate(_uart1_handle_isr, "uart1HandleIsr", 2*RX_BUFFER_SIZE, NULL, 12, NULL);
+    xTaskCreate(_uart1_handle_isr, "uart1HandleIsr", 2*RX_BUFFER_SIZE, NULL, 10, NULL);
     uartEnableInterrupt(uart1, true);
 
     static const periph_pin_t tx = {
@@ -655,7 +655,7 @@ const io_stream_t *serial2Init (uint32_t baud_rate)
     uart_driver_install(uart2->num, RX_BUFFER_SIZE, TX_BUFFER_SIZE, RX_BUFFER_SIZE, &_uart2_queue, 0);
 
     serial2Flush();
-    xTaskCreate(_uart2_handle_isr, "uart2HandleIsr", 2*RX_BUFFER_SIZE, NULL, 12, NULL);
+    xTaskCreate(_uart2_handle_isr, "uart2HandleIsr", 2*RX_BUFFER_SIZE, NULL, 10, NULL);
 #ifdef UART2_TX_PIN
     uartEnableInterrupt(uart2, true);
 

--- a/main/esp32-hal-uart.c
+++ b/main/esp32-hal-uart.c
@@ -88,7 +88,7 @@ static uart_config_t uart1Config = {
     .data_bits=UART_DATA_8_BITS,
     .parity=UART_PARITY_DISABLE,
     .stop_bits=UART_STOP_BITS_2,
-    .flow_ctrl=UART_HW_FLOWCTRL_RTS,
+    .flow_ctrl=UART_HW_FLOWCTRL_DISABLE,
     .rx_flow_ctrl_thresh=0,
 };
 static QueueHandle_t _uart1_queue;


### PR DESCRIPTION
Hi!
A time ago I discovered a bug on my fork of this repository. When I set the baudrate to 460800 and above, when getting the response of some commands like "$ESG" or "$ESH" the list of settings was broken. (when the baudrate is 460800 this bug occurs sometimes, but when using 921600 it always occurs).
I was thinking that this was a problem with my fork, but when setting the main repository to the same settings, the same problem occurs. When testing with Teensy 4.1 nothing of this occurs.

So, after seeing this issue #43 , I tried to port the code to esp-idf v5.0, but this gave a lot of problems when compiling(it's not a stable version). So, for me, this is not an option right now.
Then I use the esp-idf v4.4(the latest stable) and the uart code simply bugs. It seems that the isr was reading the full ringBuffer every time a char is passed to the input. Simply compiling the code with the idf v4.4 gave me this error. 
I reworked the code and make it work with the high-level functions of uart, and this resolve all the issues I have written.
Bonus: Using these high-level functions will help when migrating to esp-idf v5(when this becomes stable).

To clarify, using idf v4.3 and the current code for uart was giving me these errors of response. To resolve this I migrate the code to the high-level functions. And with this migration, we can now use idf v4.4 .

In my tests, all worked well, the only thing that I don't know if continues to work is the Modbus code. With the different handling of the isr I needed to change the code a little bit.

Obs: The problem with the responses only occurs when running a sender, if I simply ask for $ESG on the esp-idf monitor, it gives me all the responses correctly. I get this error running bCNC and tried different polling rates and no matter what I choose the responses are always broken.