### PR TITLE
on_message_received called with data_lenght instead of topic_length

### DIFF
--- a/main/mqtt.c
+++ b/main/mqtt.c
@@ -83,7 +83,7 @@ static void event_handler_callback (void *arg, esp_event_base_t event_base, int3
 /*            if(arg != NULL)
                 ((on_mqtt_message_received_ptr)arg)(mqtt_message.topic, (void *)mqtt_message.payload, mqtt_message.payload_length);
             else*/ if(mqtt_events.on_message_received)
-                mqtt_events.on_message_received(event->topic, (void *)event->data, (size_t)event->topic_len);
+                mqtt_events.on_message_received(event->topic, (void *)event->data, (size_t)event->data_len);
             break;
 
         default:


### PR DESCRIPTION
From the examples it is clear that it should be called with data_length and  not topic_length.

For further improvements, in my opinion it should be called with both arguments, data_length and topic_length. That will require edits to networking/mqtt.h and will maybe break some user plugins in case they exists and may require edits to the mqtt.c files on other platorms different from esp32. I can give a look into it if you want me to.