### PR TITLE
Add MPG support.

### DIFF
--- a/main/boards/mks_dlc32_2_0_map.h
+++ b/main/boards/mks_dlc32_2_0_map.h
@@ -137,3 +137,9 @@
 #define I2C_SCL             GPIO_NUM_4
 #define I2C_CLOCK           100000
 #endif
+
+#if MPG_ENABLE == 1
+// Use GPIO33 (EXP1) for MPG_MODE.
+// MPG UART is IO18/19 (EXP2).
+#define MPG_MODE_PIN            AUXINPUT0_PIN
+#endif


### PR DESCRIPTION
This PR makes the ESP32 driver compile with MPG_ENABLE set to 1.

Unfortunately it is not much use at the moment, as I get a `Core  1 panic` whenever the MPG mode switch pin changes state:

```
0x400e8cc3: io_wait_on_input at /project/build/../main/grbl/ioports.c:675
0x4008405e: aux_irq_handler at /project/build/../main/driver.c:1882
0x40084ae5: ioports_event at /project/build/../main/ioports.c:174 (discriminator 4)
0x400844b2: gpio_isr at /project/build/../main/driver.c:3945
0x400829b1: _xt_lowint1 at /opt/esp/idf/components/freertos/port/xtensa/xtensa_vectors.S:1105
0x4008910b: xQueueReceive at /opt/esp/idf/components/freertos/queue.c:1405
0x40084fcd: i2sOutTask at /project/build/../main/i2s_out.c:470
```

But at least it is a starting point if anyone wants to debug further.