### PR TITLE
Update AUXINPUT0 to GPIO 42

### DIFF
--- a/main/boards/generic_s3_map.h
+++ b/main/boards/generic_s3_map.h
@@ -80,7 +80,7 @@
 #define COOLANT_MIST_PIN        AUXOUTPUT4_PIN
 #endif
 
-#define AUXINPUT0_PIN           GPIO_NUM_1
+#define AUXINPUT0_PIN           GPIO_NUM_42
 #define AUXINPUT1_PIN           GPIO_NUM_2
 #if !SDCARD_ENABLE
 #define AUXINPUT2_PIN           GPIO_NUM_38 // Reset/EStop


### PR DESCRIPTION
This PR changes the pin mapping for `AUXINPUT0_PIN` from `GPIO_NUM_1` to `GPIO_NUM_42` on the generic ESP32-S3 map to better match my custom hardware configuration and avoid sensor setup conflicts. 

The change is isolated to a single pin modification and does not affect other shared inputs.
