### PR TITLE
esp32s3: hand off native USB CDC to ROM bootloader

### DIFF
--- a/main/driver.c
+++ b/main/driver.c
@@ -63,20 +63,18 @@
 #include "esp32s3/clk.h"
 #if USB_SERIAL_CDC
 #include "usb_serial.h"
-#include "soc/soc.h"
-#include "soc/rtc_cntl_reg.h"
 status_code_t enter_bootloader (sys_state_t state, char *args)
 {
+    (void)state;
+    (void)args;
 
     hal.stream.write("[MSG:Warning: Entering ESP32 Bootloader]" ASCII_EOL);
     hal.delay_ms(100, NULL);
 
-    REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
-    esp_restart();
-    return Status_OK;
+    return usb_serialEnterBootloader() ? Status_OK : Status_InvalidStatement;
 }
 
-#endif // USB_SERIAL_CDC
+#endif
 #endif
 
 #if WIFI_ENABLE

--- a/main/usb_serial.c
+++ b/main/usb_serial.c
@@ -35,9 +35,23 @@
 
 #include <stdint.h>
 #include "esp_log.h"
+#include "esp_intr_alloc.h"
+#include "esp_private/usb_phy.h"
+#include "esp_rom_sys.h"
+#include "esp_system.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
+#include "driver/gpio.h"
+#include "hal/clk_gate_ll.h"
+#include "hal/usb_phy_ll.h"
+#include "hal/usb_serial_jtag_ll.h"
+#include "soc/periph_defs.h"
+#include "soc/rtc_cntl_reg.h"
+#include "soc/usb_pins.h"
+#include "soc/usb_serial_jtag_reg.h"
 #include "tinyusb.h"
+#include "tusb_tasks.h"
 #include "tusb_cdc_acm.h"
 
 #include <string.h>
@@ -50,6 +64,94 @@
 static stream_block_tx_buffer_t txbuf = {0};
 static stream_rx_buffer_t rxbuf;
 static volatile enqueue_realtime_command_ptr enqueue_realtime_command = protocol_enqueue_realtime_command;
+static bool usb_serial_started = false;
+static bool usb_bootloader_restart_pending = false;
+static usb_phy_handle_t usb_serial_phy_hdl = NULL;
+
+/*
+ * ESP-IDF 4.4 exposes TinyUSB install but not uninstall. The stock driver keeps
+ * the OTG PHY handle private, which prevents the ESP32-S3 bootloader handoff
+ * used by Arduino from tearing the PHY down before switching to USB Serial/JTAG.
+ *
+ * This follows the Arduino-ESP32 native USB path:
+ * - cores/esp32/esp32-hal-tinyusb.c: usb_switch_to_cdc_jtag()
+ * - cores/esp32/USBCDC.cpp: usb_persist_restart(RESTART_BOOTLOADER)
+ */
+extern tusb_desc_device_t descriptor_kconfig;
+extern tusb_desc_strarray_device_t descriptor_str_kconfig;
+void tusb_set_descriptor (tusb_desc_device_t *desc, const char **str_desc);
+
+static void hw_cdc_reset_handler (void *arg)
+{
+    BaseType_t xTaskWoken = pdFALSE;
+    uint32_t usbjtag_intr_status = usb_serial_jtag_ll_get_intsts_mask();
+
+    usb_serial_jtag_ll_clr_intsts_mask(usbjtag_intr_status);
+
+    if(usbjtag_intr_status & USB_SERIAL_JTAG_INTR_BUS_RESET)
+        xSemaphoreGiveFromISR((SemaphoreHandle_t)arg, &xTaskWoken);
+
+    if(xTaskWoken == pdTRUE)
+        portYIELD_FROM_ISR();
+}
+
+static void usb_serial_bootloader_shutdown_handler (void)
+{
+    if(!usb_bootloader_restart_pending)
+        return;
+
+    REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+}
+
+static esp_err_t usb_serial_driver_install (const tinyusb_config_t *config)
+{
+    usb_phy_config_t phy_conf = {
+        .controller = USB_PHY_CTRL_OTG,
+        .target = USB_PHY_TARGET_INT,
+        .otg_mode = USB_OTG_MODE_DEVICE
+    };
+    tusb_desc_device_t *dev_descriptor;
+    const char **string_descriptor;
+    esp_err_t err;
+
+    if(config == NULL)
+        return ESP_ERR_INVALID_ARG;
+
+    err = usb_new_phy(&phy_conf, &usb_serial_phy_hdl);
+    if(err != ESP_OK)
+        return err;
+
+    dev_descriptor = config->descriptor ? config->descriptor : &descriptor_kconfig;
+    string_descriptor = config->string_descriptor ? config->string_descriptor : descriptor_str_kconfig;
+
+    tusb_set_descriptor(dev_descriptor, string_descriptor);
+
+    if(!tusb_init()) {
+        usb_del_phy(usb_serial_phy_hdl);
+        usb_serial_phy_hdl = NULL;
+        return ESP_FAIL;
+    }
+
+    err = tusb_run_task();
+
+    if(err != ESP_OK) {
+        usb_del_phy(usb_serial_phy_hdl);
+        usb_serial_phy_hdl = NULL;
+    }
+
+    return err;
+}
+
+static void usb_serial_driver_uninstall (void)
+{
+    if(usb_serial_phy_hdl)
+        tusb_stop_task();
+
+    if(usb_serial_phy_hdl) {
+        usb_del_phy(usb_serial_phy_hdl);
+        usb_serial_phy_hdl = NULL;
+    }
+}
 
 static inline bool usb_connected (void)
 {
@@ -271,6 +373,58 @@ void usb_line_state_callback (int itf, cdcacm_event_t *event)
     stream_usb_linestate_changed(0, (serial_linestate_t){ .dtr = event->line_state_changed_data.dtr, .rts = event->line_state_changed_data.rts });
 }
 
+bool usb_serialEnterBootloader (void)
+{
+    intr_handle_t intr_handle = NULL;
+    SemaphoreHandle_t reset_sem = NULL;
+
+    if(!usb_serial_started)
+        return false;
+
+    usb_serial_driver_uninstall();
+    periph_ll_reset(PERIPH_USB_MODULE);
+    periph_ll_disable_clk_set_rst(PERIPH_USB_MODULE);
+
+    CLEAR_PERI_REG_MASK(RTC_CNTL_USB_CONF_REG, RTC_CNTL_SW_HW_USB_PHY_SEL | RTC_CNTL_SW_USB_PHY_SEL | RTC_CNTL_USB_PAD_ENABLE);
+    CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_PHY_SEL);
+    CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+
+    // Force a disconnect while re-routing the internal PHY from USB OTG to USB Serial/JTAG.
+    gpio_set_direction(USBPHY_DM_NUM, GPIO_MODE_OUTPUT_OD);
+    gpio_set_direction(USBPHY_DP_NUM, GPIO_MODE_OUTPUT_OD);
+    gpio_set_level(USBPHY_DM_NUM, 0);
+    gpio_set_level(USBPHY_DP_NUM, 0);
+
+    usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
+    usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
+    usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
+    usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_BUS_RESET);
+
+    reset_sem = xSemaphoreCreateBinary();
+    if(reset_sem && esp_intr_alloc(ETS_USB_SERIAL_JTAG_INTR_SOURCE, 0, hw_cdc_reset_handler, reset_sem, &intr_handle) == ESP_OK) {
+        SET_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+        xSemaphoreTake(reset_sem, pdMS_TO_TICKS(1000));
+    } else
+        SET_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+
+    usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
+
+    if(intr_handle)
+        esp_intr_free(intr_handle);
+
+    if(reset_sem)
+        vSemaphoreDelete(reset_sem);
+
+    usb_bootloader_restart_pending = esp_register_shutdown_handler(usb_serial_bootloader_shutdown_handler) == ESP_OK;
+
+    if(!usb_bootloader_restart_pending)
+        REG_WRITE(RTC_CNTL_OPTION1_REG, RTC_CNTL_FORCE_DOWNLOAD_BOOT);
+
+    esp_restart();
+
+    return true;
+}
+
 const io_stream_t *usb_serialInit (void)
 {
     static const io_stream_t stream = {
@@ -301,8 +455,9 @@ const io_stream_t *usb_serialInit (void)
         .callback_line_coding_changed = NULL
     };
 
-    tinyusb_driver_install(&tusb_cfg);
+    usb_serial_driver_install(&tusb_cfg);
     tusb_cdc_acm_init(&acm_cfg);
+    usb_serial_started = true;
 
     txbuf.s = txbuf.data;
     txbuf.max_length = CFG_TUD_CDC_TX_BUFSIZE;

--- a/main/usb_serial.h
+++ b/main/usb_serial.h
@@ -27,5 +27,6 @@
 #include "grbl/hal.h"
 
 const io_stream_t *usb_serialInit(void);
+bool usb_serialEnterBootloader (void);
 
 /*EOF*/


### PR DESCRIPTION
Replace the direct RTC download reset used initially in my first attempt at implementing $bootloader with a native USB handoff path that tears down TinyUSB CDC before restarting into the ESP32-S3 ROM downloader.

driver.c now routes enter_bootloader() through usb_serialEnterBootloader() so the USB transport owns the full transition instead of forcing download mode while the TinyUSB stack still owns the OTG PHY.

usb_serial.c adds a local TinyUSB install/uninstall wrapper because ESP-IDF 4.4 exposes tinyusb_driver_install() but does not expose a matching uninstall API, and the stock implementation keeps the OTG PHY handle private. Owning that PHY handle locally is required to release USB OTG cleanly before switching the internal PHY over to USB Serial/JTAG for the ROM bootloader.

The handoff sequence follows the Arduino-ESP32 ESP32-S3 native USB implementation, specifically cores/esp32/esp32-hal-tinyusb.c (usb_switch_to_cdc_jtag()) and cores/esp32/USBCDC.cpp (usb_persist_restart(RESTART_BOOTLOADER)). This implementation uninstalls TinyUSB, resets the USB peripheral, forces a temporary disconnect on D+/D-, enables USB Serial/JTAG, waits for a bus reset when available, and latches RTC_CNTL_FORCE_DOWNLOAD_BOOT through a shutdown handler before esp_restart().

usb_serial.h exports the new bootloader handoff entry point used by the driver.

This version improved on the original implementation and is way more robust - i have done quite a bit of testing. The old method would often fail to release the TinyUSB port and thus just hang the port instead of bootloader port coming up.