### PR TITLE
Align Ooznest PIO env with Web Builder profile

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -137,6 +137,9 @@ build_flags =
     -DN_AXIS=4
     -DASYMMETRIC_AUTO_SQUARE=Y_AXIS
 
+    -DDEFAULT_HOMING_SINGLE_AXIS_COMMANDS=1
+    -DDEFAULT_HOMING_INIT_LOCK=1
+
 board_build.flash_mode = dio
 board_build.f_flash = 40000000L
 board_upload.flash_size = 4MB


### PR DESCRIPTION
Just added firmware settings which I have changed in Web Builder profile too
- Force home on startup
- Allow Home Individual Axis