### PR TITLE
Fix spindle/laser PWM on ESP32-S3: LEDC channel configured with invalid LEDC_SPEED_MODE_MAX

### DIFF
--- a/main/driver.c
+++ b/main/driver.c
@@ -163,7 +163,7 @@ static pwm_spindle_t pwm_spindle = {
     .channel = {
         .gpio_num = SPINDLE_PWM_PIN,
 #if CONFIG_IDF_TARGET_ESP32S3
-        .speed_mode = LEDC_SPEED_MODE_MAX,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
 #else
         .speed_mode = LEDC_HIGH_SPEED_MODE,
 #endif
@@ -199,7 +199,7 @@ static pwm_spindle_t pwm_spindle1 = {
     .channel = {
         .gpio_num = SPINDLE1_PWM_PIN,
 #if CONFIG_IDF_TARGET_ESP32S3
-        .speed_mode = LEDC_SPEED_MODE_MAX,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
 #else
         .speed_mode = LEDC_HIGH_SPEED_MODE,
 #endif


### PR DESCRIPTION
On `CONFIG_IDF_TARGET_ESP32S3` the LEDC **channel** config for both PWM spindles sets `.speed_mode = LEDC_SPEED_MODE_MAX`, while the corresponding **timer** config (correctly) uses `LEDC_LOW_SPEED_MODE`.

`LEDC_SPEED_MODE_MAX` is the enum element count, not a valid mode — `ledc_channel_config()` fails its argument check, so the spindle/laser PWM never appears on the pin on S3 targets. Since the S3 only has the low-speed LEDC group, the channel must use `LEDC_LOW_SPEED_MODE` to match the timer.

**Tested on real hardware:** ESP32-S3-WROOM-1U (N8R2) driving a 10 W diode laser (VEVOR A7 / AtomStack YZ-102 "LaserBox 40pro" board). Before the change: no PWM output at all on the laser pin; after: clean 1 kHz PWM, laser fully controllable with M3/M4 + S. Full board bring-up documented at https://github.com/levshacoua/vevor-a7-grblhal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)